### PR TITLE
Fix devices.yaml path

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ jq -c '.data.devices[]' /homeassistant/.storage/core.device_registry | while rea
     mac=$(echo "$id" | jq -r '.[1]' | tr -d ':')
     name=$(echo "$dev" | jq -r '.name_by_user // .name' | sed "s/'/''/g")
     
-    echo "'0x$mac':" >> devices.yaml
+    echo "'0x$mac':" >> /homeassistant/zigbee2mqtt/devices.yaml
     echo "    friendly_name: '$name'" >> /homeassistant/zigbee2mqtt/devices.yaml
 done
 ```


### PR DESCRIPTION
Seems like a typo in path to `devices.yaml`

Also a couple of notes:
- if zigbee2mqtt `configuration.yaml` already contains `devices:` section, there will be a conflict
- in my particular case, filling database, config and network params wasn't enough, I had to re-pair all devices